### PR TITLE
Add standard GOV.UK Github security checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,16 @@ on:
   pull_request:
 
 jobs:
+  codeql-sast:
+    name: CodeQL SAST scan
+    uses: alphagov/govuk-infrastructure/.github/workflows/codeql-analysis.yml@main
+    permissions:
+      security-events: write
+
+  dependency-review:
+    name: Dependency Review scan
+    uses: alphagov/govuk-infrastructure/.github/workflows/dependency-review.yml@main
+
   test:
     name: Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is to bring this repo consistent with other GOV.UK repos. I'm not 100% sure they'll work as this is a Python repo but I think they're both language agnostic.