### PR TITLE
Don't run real_openai_tests for dependabot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,9 @@ jobs:
       - name: Run regular tests
         run: uv run pytest tests
 
-      - name: Run real_openai tests
+      # Don't real these tests for dependabot to avoid needing to share OpenAI API key
+      - if: github.actor != 'dependabot[bot]'
+        name: Run real_openai tests
         run: uv run pytest -m 'real_openai' tests
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
These tests are currently failing for Dependabot as they require a secret and our OpenAI API key is not a Dependabot secret.

We had 2 options here:

1) exclude these tests from Dependabot
2) create a Dependabot secret for it

I chose to go with the former as I understood the best practice is to not share secrets with Dependabot if you can avoid it, which reduces the risk that a malicious Python package could steal it (should it be opened as a PR and not merged, once merged all bets are off).

This does carry a risk that the tests could be failing and we'd not notice until we merge to main, but I think this risk is relatively low as I don't think the real OpenAI tests exercise code that is outside of relative coverage.