### PR TITLE
Make dataset generation concurrency configurable

### DIFF
--- a/tests/test_dataset_generation.py
+++ b/tests/test_dataset_generation.py
@@ -76,7 +76,9 @@ async def test_generate_dataset():
             return {"input": item, "output": f"generated-{item}"}
 
     ground_truth = ["question1", "question2", "question3"]
-    result = await generate_dataset(ground_truth, mock_generation_func)
+    result = await generate_dataset(
+        ground_truth, mock_generation_func, max_concurrent=3
+    )
 
     expected_result = [
         {"input": "question1", "output": "generated-question1"},


### PR DESCRIPTION
Updated async generate_dataset to accept an optional max_concurrent parameter (default MAX_CONCURRENT) instead of a hardcoded semaphore of 10. This allows controlling the number of concurrent tasks to avoid API rate limits.

I had to lower it down to 5 in order to avoid rate limits during extensive testing in preparation of pre-App launch.

Added a test to ensure max_concurrent is passed correctly to the semaphore. Existing behavior and failure handling remain unchanged.

NOTE: The current implementation is not ideal, as the default concurrency
is still set via MAX_CONCURRENT in the Python module. This can be moved
to a config file when one exists, but this change makes it clear that
the concurrency may need to be configured.