### PR TITLE
Handling error metric output rag answers

### DIFF
--- a/govuk_chat_evaluation/rag_answers/data_models.py
+++ b/govuk_chat_evaluation/rag_answers/data_models.py
@@ -161,10 +161,11 @@ class Config(BaseConfig):
 class RunMetricOutput:
     run: int
     metric: str
-    score: float
+    score: float | None = None
     cost: float | None = None
     reason: str | None = None
     success: bool | None = None
+    error: str | None = None
 
 
 @dataclass

--- a/govuk_chat_evaluation/rag_answers/deepeval_evaluate.py
+++ b/govuk_chat_evaluation/rag_answers/deepeval_evaluate.py
@@ -128,10 +128,11 @@ def convert_deepeval_output_to_evaluation_results(
                         RunMetricOutput(
                             run=run_idx,
                             metric=metric_data.name,
-                            score=metric_data.score,
-                            reason=metric_data.reason,
-                            cost=metric_data.evaluation_cost,
-                            success=metric_data.success,
+                            score=getattr(metric_data, "score", None),
+                            reason=getattr(metric_data, "reason", None),
+                            cost=getattr(metric_data, "evaluation_cost", None),
+                            success=getattr(metric_data, "success", None),
+                            error=getattr(metric_data, "error", None),
                         )
                     )
 

--- a/govuk_chat_evaluation/rag_answers/deepeval_evaluate.py
+++ b/govuk_chat_evaluation/rag_answers/deepeval_evaluate.py
@@ -128,11 +128,11 @@ def convert_deepeval_output_to_evaluation_results(
                         RunMetricOutput(
                             run=run_idx,
                             metric=metric_data.name,
-                            score=getattr(metric_data, "score", None),
-                            reason=getattr(metric_data, "reason", None),
-                            cost=getattr(metric_data, "evaluation_cost", None),
-                            success=getattr(metric_data, "success", None),
-                            error=getattr(metric_data, "error", None),
+                            score=metric_data.score,
+                            reason=metric_data.reason,
+                            cost=metric_data.evaluation_cost,
+                            success=metric_data.success,
+                            error=metric_data.error,
                         )
                     )
 

--- a/govuk_chat_evaluation/rag_answers/evaluate.py
+++ b/govuk_chat_evaluation/rag_answers/evaluate.py
@@ -108,6 +108,7 @@ class AggregatedResults:
                         "input": eval_result.input,
                         "metric": evaluation_output.metric,
                         "score": evaluation_output.score,
+                        "error": evaluation_output.error,
                     }
                 )
 
@@ -115,9 +116,10 @@ class AggregatedResults:
 
         return (
             df.groupby(["name", "input", "metric"])["score"]
-            .agg(["mean", "std"])
+            .agg(["mean", "std", "count"])
             .unstack()
             .reset_index()
+            .rename(columns={"count": "n_datapoints"})
         )
 
     @cached_property
@@ -136,6 +138,7 @@ class AggregatedResults:
                 "median": mean_df.median(),
                 "mean": mean_df.mean(),
                 "std": mean_df.std(),
+                "n_datapoints": self.per_input_metric_averages["n_datapoints"].sum(),
             }
         )
 

--- a/tests/rag_answers/test_evaluate.py
+++ b/tests/rag_answers/test_evaluate.py
@@ -61,6 +61,23 @@ class TestAggregateResults:
                     RunMetricOutput(run=0, metric="bias", score=0.0),
                 ],
             ),
+            EvaluationResult(
+                name="Test3",
+                input="What error can occur?",
+                actual_output="Completion rate limited",
+                expected_output="Completion rate limited",
+                retrieval_context=[],
+                run_metric_outputs=[
+                    RunMetricOutput(run=0, metric="faithfulness", score=1.0),
+                    RunMetricOutput(
+                        run=1,
+                        metric="faithfulness",
+                        error="Some error occurred while producing deepeval metric output",
+                    ),
+                    RunMetricOutput(run=0, metric="bias", score=0.2),
+                    RunMetricOutput(run=0, metric="bias", score=0.1),
+                ],
+            ),
         ]
 
     def test_per_input_metric_averages(self, mock_evaluation_results):
@@ -75,17 +92,20 @@ class TestAggregateResults:
             ("mean", "faithfulness"),
             ("std", "bias"),
             ("std", "faithfulness"),
+            ("n_datapoints", "bias"),
+            ("n_datapoints", "faithfulness"),
         ]
-        assert list(metric_averages[("name", "")]) == ["Test1", "Test2"]
+        assert list(metric_averages[("name", "")]) == ["Test1", "Test2", "Test3"]
         assert list(metric_averages[("input", "")]) == [
             "Is Vat a tax?",
             "What is capital of France?",
+            "What error can occur?",
         ]
 
     def test_summary(self, mock_evaluation_results):
         summary = AggregatedResults(mock_evaluation_results).summary
         assert isinstance(summary, pd.DataFrame)
-        assert list(summary.columns) == ["median", "mean", "std"]
+        assert list(summary.columns) == ["median", "mean", "std", "n_datapoints"]
         assert list(summary.index) == ["bias", "faithfulness"]
 
     def test_export_to_csvs(self, mock_evaluation_results, tmp_path):

--- a/tests/rag_answers/test_evaluate.py
+++ b/tests/rag_answers/test_evaluate.py
@@ -50,19 +50,6 @@ class TestAggregateResults:
             ),
             EvaluationResult(
                 name="Test2",
-                input="What is capital of France?",
-                actual_output="Paris",
-                expected_output="Paris",
-                retrieval_context=[],
-                run_metric_outputs=[
-                    RunMetricOutput(run=0, metric="faithfulness", score=1.0),
-                    RunMetricOutput(run=1, metric="faithfulness", score=1.0),
-                    RunMetricOutput(run=0, metric="bias", score=0.0),
-                    RunMetricOutput(run=0, metric="bias", score=0.0),
-                ],
-            ),
-            EvaluationResult(
-                name="Test3",
                 input="What error can occur?",
                 actual_output="Completion rate limited",
                 expected_output="Completion rate limited",
@@ -75,7 +62,7 @@ class TestAggregateResults:
                         error="Some error occurred while producing deepeval metric output",
                     ),
                     RunMetricOutput(run=0, metric="bias", score=0.2),
-                    RunMetricOutput(run=0, metric="bias", score=0.1),
+                    RunMetricOutput(run=1, metric="bias", score=0.1),
                 ],
             ),
         ]
@@ -95,12 +82,13 @@ class TestAggregateResults:
             ("n_datapoints", "bias"),
             ("n_datapoints", "faithfulness"),
         ]
-        assert list(metric_averages[("name", "")]) == ["Test1", "Test2", "Test3"]
+        assert list(metric_averages[("name", "")]) == ["Test1", "Test2"]
         assert list(metric_averages[("input", "")]) == [
             "Is Vat a tax?",
-            "What is capital of France?",
             "What error can occur?",
         ]
+        assert list(metric_averages[("n_datapoints", "bias")]) == [2, 2]
+        assert list(metric_averages[("n_datapoints", "faithfulness")]) == [2, 1]
 
     def test_summary(self, mock_evaluation_results):
         summary = AggregatedResults(mock_evaluation_results).summary


### PR DESCRIPTION
This PR fixes pipeline crashes caused by DeepEval metrics returning errors (e.g. LLM completion failures such as rate limits) without a score field. The changes ensure errors are properly propagated, failed cases are tracked, and reports reflect which datapoints were successfully evaluated.

**Changes**

- Added an error field to RunMetricOutput to capture and propagate error messages from DeepEval metrics
- Make score field in RunMetricOutput optional
- Enhanced per-input and summary reports to include datapoint counts per metric, making it easier to spot missing or failed evaluations

**Why**

Previously, if DeepEval returned an error (e.g. OpenAI rate limit or other LLM completion issues), the metric object would not include a score. Since the pipeline assumed all metrics had a score, this caused unhandled errors and broke execution.

This was caused by those metrics, like faithfulness, that need to produce a lot of interim outputs.

With this update, errors are safely handled, failures are visible in the reports, and overall pipeline robustness is improved.